### PR TITLE
RefreshToken Expire ermöglicht

### DIFF
--- a/oauth-server/src/main/java/de/adorsys/oauth/server/TokenResource.java
+++ b/oauth-server/src/main/java/de/adorsys/oauth/server/TokenResource.java
@@ -33,20 +33,14 @@ import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Context;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -69,13 +63,16 @@ public class TokenResource extends HttpServlet {
     private TokenStore tokenStore;
 
     private long tokenLifetime;
+    private long refreshTokenLifetime;
     
     @Override
     public void init(ServletConfig config) throws ServletException {
 	   try {
            tokenLifetime = Long.valueOf(config.getServletContext().getInitParameter("lifetime"));
+           refreshTokenLifetime = Long.valueOf(config.getServletContext().getInitParameter("refreshlifetime"));
        } catch (Exception e) {
            tokenLifetime = 8 * 3600;
+           refreshTokenLifetime = 0L;
        }
 
        LOG.info("token lifetime {}", tokenLifetime);
@@ -131,7 +128,7 @@ public class TokenResource extends HttpServlet {
             return;
     	}
     	RefreshToken refreshToken = new RefreshToken();
-    	tokenStore.addRefreshToken(refreshToken,  refreshTokeMetadata.getUserInfo(), refreshTokeMetadata.getClientId(), refreshTokeMetadata.getLoginSession());
+    	tokenStore.addRefreshToken(refreshToken,  refreshTokeMetadata.getUserInfo(), refreshTokeMetadata.getClientId(), refreshTokeMetadata.getLoginSession(), refreshTokenLifetime);
     	BearerAccessToken accessToken = new BearerAccessToken(tokenLifetime, request.getScope());
     	tokenStore.addAccessToken(accessToken, refreshTokeMetadata.getUserInfo(), refreshTokeMetadata.getClientId(), refreshToken);
     	
@@ -189,7 +186,7 @@ public class TokenResource extends HttpServlet {
 
         RefreshToken refreshToken = new RefreshToken();
         LOG.debug("request.getClientAuthentication() {}", request.getClientAuthentication());
-		tokenStore.addRefreshToken(refreshToken, userInfo, request.getClientAuthentication().getClientID(), null);
+		tokenStore.addRefreshToken(refreshToken, userInfo, request.getClientAuthentication().getClientID(), null, refreshTokenLifetime);
 
         BearerAccessToken accessToken = new BearerAccessToken(tokenLifetime, request.getScope());
 

--- a/oauth-server/src/main/java/de/adorsys/oauth/server/TokenResource.java
+++ b/oauth-server/src/main/java/de/adorsys/oauth/server/TokenResource.java
@@ -63,19 +63,20 @@ public class TokenResource extends HttpServlet {
     private TokenStore tokenStore;
 
     private long tokenLifetime;
-    private long refreshTokenLifetime;
+    private int refreshTokenLifetime;
     
     @Override
     public void init(ServletConfig config) throws ServletException {
 	   try {
            tokenLifetime = Long.valueOf(config.getServletContext().getInitParameter("lifetime"));
-           refreshTokenLifetime = Long.valueOf(config.getServletContext().getInitParameter("refreshlifetime"));
+           refreshTokenLifetime = Integer.valueOf(config.getServletContext().getInitParameter("refreshlifetime"));
        } catch (Exception e) {
            tokenLifetime = 8 * 3600;
-           refreshTokenLifetime = 0L;
+           refreshTokenLifetime = 0;
        }
 
        LOG.info("token lifetime {}", tokenLifetime);
+       LOG.info("refresh token lifetime {}", refreshTokenLifetime);
     }
     
     @Override

--- a/oauth-server/src/main/java/de/adorsys/oauth/server/TokenStore.java
+++ b/oauth-server/src/main/java/de/adorsys/oauth/server/TokenStore.java
@@ -35,7 +35,7 @@ public interface TokenStore {
 
     void addRefreshToken(RefreshToken token, UserInfo userInfo, ClientID clientId, LoginSessionToken sessionId);
 
-    void addRefreshToken(RefreshToken token, UserInfo userInfo, ClientID clientId, LoginSessionToken sessionId, long refreshLifeTime);
+    void addRefreshToken(RefreshToken token, UserInfo userInfo, ClientID clientId, LoginSessionToken sessionId, long refreshTokenLifetime);
 
     void addAccessToken(BearerAccessToken token, UserInfo userInfo, ClientID clientId, RefreshToken refreshToken);
     

--- a/oauth-server/src/main/java/de/adorsys/oauth/server/TokenStore.java
+++ b/oauth-server/src/main/java/de/adorsys/oauth/server/TokenStore.java
@@ -15,14 +15,14 @@
  */
 package de.adorsys.oauth.server;
 
-import java.net.URI;
-
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+
+import java.net.URI;
 
 /**
  * TokenStore
@@ -34,6 +34,8 @@ public interface TokenStore {
 	void addAuthCode(AuthorizationCode token, UserInfo userInfo, ClientID clientId, LoginSessionToken sessionId, URI redirectUri);
 
     void addRefreshToken(RefreshToken token, UserInfo userInfo, ClientID clientId, LoginSessionToken sessionId);
+
+    void addRefreshToken(RefreshToken token, UserInfo userInfo, ClientID clientId, LoginSessionToken sessionId, long refreshLifeTime);
 
     void addAccessToken(BearerAccessToken token, UserInfo userInfo, ClientID clientId, RefreshToken refreshToken);
     

--- a/oauth-server/src/main/java/de/adorsys/oauth/server/TokenStore.java
+++ b/oauth-server/src/main/java/de/adorsys/oauth/server/TokenStore.java
@@ -35,7 +35,7 @@ public interface TokenStore {
 
     void addRefreshToken(RefreshToken token, UserInfo userInfo, ClientID clientId, LoginSessionToken sessionId);
 
-    void addRefreshToken(RefreshToken token, UserInfo userInfo, ClientID clientId, LoginSessionToken sessionId, long refreshTokenLifetime);
+    void addRefreshToken(RefreshToken token, UserInfo userInfo, ClientID clientId, LoginSessionToken sessionId, int refreshTokenLifetime);
 
     void addAccessToken(BearerAccessToken token, UserInfo userInfo, ClientID clientId, RefreshToken refreshToken);
     

--- a/oauth-test/src/test/resources/deployments/idp.war/WEB-INF/web.xml
+++ b/oauth-test/src/test/resources/deployments/idp.war/WEB-INF/web.xml
@@ -7,6 +7,10 @@
         <param-value>15</param-value>
     </context-param>
     <context-param>
+      <param-name>refreshlifetime</param-name>
+      <param-value>1</param-value>
+    </context-param>
+    <context-param>
         <param-name>checkClientCredentialsOnTokenRevoke</param-name>
         <param-value>false</param-value>
     </context-param>

--- a/oauth-test/src/test/resources/wildfly-idp/web.xml
+++ b/oauth-test/src/test/resources/wildfly-idp/web.xml
@@ -23,10 +23,14 @@
 		<param-name>lifetime</param-name>
 		<param-value>15</param-value>
 	</context-param>
+  <context-param>
+    <param-name>refreshlifetime</param-name>
+    <param-value>15</param-value>
+  </context-param>
 	<context-param>
-        <param-name>checkClientCredentialsOnTokenRevoke</param-name>
-        <param-value>false</param-value>
-    </context-param>
+      <param-name>checkClientCredentialsOnTokenRevoke</param-name>
+      <param-value>false</param-value>
+  </context-param>
 
 	<security-constraint>
 		<web-resource-collection>

--- a/oauth-tokenstore-jpa/src/main/java/de/adorsys/oauth/tokenstore/jpa/JpaTokenStore.java
+++ b/oauth-tokenstore-jpa/src/main/java/de/adorsys/oauth/tokenstore/jpa/JpaTokenStore.java
@@ -15,18 +15,6 @@
  */
 package de.adorsys.oauth.tokenstore.jpa;
 
-import java.net.URI;
-
-import javax.ejb.Stateless;
-import javax.persistence.Cache;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
-import javax.persistence.Query;
-
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
@@ -38,6 +26,17 @@ import de.adorsys.oauth.server.AuthCodeAndMetadata;
 import de.adorsys.oauth.server.LoginSessionToken;
 import de.adorsys.oauth.server.RefreshTokenAndMetadata;
 import de.adorsys.oauth.server.TokenStore;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ejb.Stateless;
+import javax.persistence.Cache;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
+
+import java.net.URI;
 
 /**
  * JpaTokenStore
@@ -77,6 +76,12 @@ public class JpaTokenStore implements TokenStore {
     public void addRefreshToken(RefreshToken token, UserInfo userInfo, ClientID clientId, LoginSessionToken sessionId) {
         TokenEntity tokenEntity = new TokenEntity(token, userInfo, clientId, sessionId);
         entityManager.persist(tokenEntity);
+    }
+
+    @Override
+    public void addRefreshToken(RefreshToken token, UserInfo userInfo, ClientID clientId, LoginSessionToken sessionId, long refreshLifeTime) {
+        // refreshLifeTime wird aktuell ignoriert
+        addRefreshToken(token, userInfo, clientId, sessionId);
     }
 
     @Override

--- a/oauth-tokenstore-jpa/src/main/java/de/adorsys/oauth/tokenstore/jpa/JpaTokenStore.java
+++ b/oauth-tokenstore-jpa/src/main/java/de/adorsys/oauth/tokenstore/jpa/JpaTokenStore.java
@@ -79,9 +79,9 @@ public class JpaTokenStore implements TokenStore {
     }
 
     @Override
-    public void addRefreshToken(RefreshToken token, UserInfo userInfo, ClientID clientId, LoginSessionToken sessionId, long refreshLifeTime) {
-        // refreshLifeTime wird aktuell ignoriert
-        addRefreshToken(token, userInfo, clientId, sessionId);
+    public void addRefreshToken(RefreshToken token, UserInfo userInfo, ClientID clientId, LoginSessionToken sessionId, int refreshTokenLifeTime) {
+        TokenEntity tokenEntity = new TokenEntity(token, userInfo, clientId, sessionId, refreshTokenLifeTime);
+        entityManager.persist(tokenEntity);
     }
 
     @Override

--- a/oauth-tokenstore-jpa/src/main/java/de/adorsys/oauth/tokenstore/jpa/TokenEntity.java
+++ b/oauth-tokenstore-jpa/src/main/java/de/adorsys/oauth/tokenstore/jpa/TokenEntity.java
@@ -158,13 +158,14 @@ public class TokenEntity {
     }
     
     public boolean isValid() {
-        
+
         AccessToken accessToken = asAccessToken();
         if (accessToken != null) {
             return expires == null || System.currentTimeMillis() < expires.getTime();
-        } 
-        
-        return asRefreshToken() != null;
+        }
+
+        RefreshToken refreshToken = asRefreshToken();
+        return refreshToken != null && (expires == null || System.currentTimeMillis() < expires.getTime());
     }
 
     @Override

--- a/oauth-tokenstore-jpa/src/main/java/de/adorsys/oauth/tokenstore/jpa/TokenEntity.java
+++ b/oauth-tokenstore-jpa/src/main/java/de/adorsys/oauth/tokenstore/jpa/TokenEntity.java
@@ -98,6 +98,10 @@ public class TokenEntity {
     }
 
     public TokenEntity(Token token, UserInfo userInfo, ClientID clientId, LoginSessionToken sessionId) {
+        this(token, userInfo, clientId, sessionId, 0);
+    }
+
+    public TokenEntity(Token token, UserInfo userInfo, ClientID clientId, LoginSessionToken sessionId, int refreshTokenLifeTime) {
         this.id    = token.getValue();
         this.token = token.toJSONObject().toJSONString();
 
@@ -105,6 +109,14 @@ public class TokenEntity {
             Calendar cal = Calendar.getInstance();
             cal.add(Calendar.SECOND, (int) ((AccessToken) token).getLifetime());
             expires = cal.getTime();
+        }
+
+        if (token instanceof RefreshToken) {
+            if (refreshTokenLifeTime != 0) {
+                Calendar cal = Calendar.getInstance();
+                cal.add(Calendar.MILLISECOND, refreshTokenLifeTime);
+                expires = cal.getTime();
+            }
         }
 
         if (userInfo != null) {

--- a/oauth-tokenstore-mongodb/src/main/java/de/adorsys/oauth/tokenstore/mongodb/MdbTokenStore.java
+++ b/oauth-tokenstore-mongodb/src/main/java/de/adorsys/oauth/tokenstore/mongodb/MdbTokenStore.java
@@ -15,6 +15,8 @@
  */
 package de.adorsys.oauth.tokenstore.mongodb;
 
+import net.minidev.json.JSONObject;
+
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
@@ -42,8 +44,6 @@ import javax.inject.Singleton;
 import java.net.URI;
 import java.util.Date;
 import java.util.Map;
-
-import net.minidev.json.JSONObject;
 
 /**
  * MdbTokenStore
@@ -94,9 +94,8 @@ public class MdbTokenStore implements TokenStore {
 	}
 
     @Override
-    public void addRefreshToken(RefreshToken token, UserInfo userInfo, ClientID clientId, LoginSessionToken sessionId, long refreshLifeTime) {
-        TokenDocument<RefreshToken> tokenDocument = new TokenDocument<RefreshToken>(token, new Date(), clientId, sessionId,
-                userInfo, refreshLifeTime);
+    public void addRefreshToken(RefreshToken token, UserInfo userInfo, ClientID clientId, LoginSessionToken sessionId, int refreshTokenLifeTime) {
+        TokenDocument<RefreshToken> tokenDocument = new TokenDocument<RefreshToken>(token, new Date(), clientId, sessionId, userInfo, refreshTokenLifeTime);
         Document document = tokenDocument.asDocument();
         collection.insertOne(document);
     }

--- a/oauth-tokenstore-mongodb/src/main/java/de/adorsys/oauth/tokenstore/mongodb/MdbTokenStore.java
+++ b/oauth-tokenstore-mongodb/src/main/java/de/adorsys/oauth/tokenstore/mongodb/MdbTokenStore.java
@@ -93,6 +93,14 @@ public class MdbTokenStore implements TokenStore {
         collection.insertOne(document);
 	}
 
+    @Override
+    public void addRefreshToken(RefreshToken token, UserInfo userInfo, ClientID clientId, LoginSessionToken sessionId, long refreshLifeTime) {
+        TokenDocument<RefreshToken> tokenDocument = new TokenDocument<RefreshToken>(token, new Date(), clientId, sessionId,
+                userInfo, refreshLifeTime);
+        Document document = tokenDocument.asDocument();
+        collection.insertOne(document);
+    }
+
 	@Override
 	public void addAccessToken(BearerAccessToken token, UserInfo userInfo, ClientID clientId, RefreshToken refreshToken) {
 		TokenDocument<BearerAccessToken> tokenDocument = new TokenDocument<BearerAccessToken>(token, new Date(), clientId, null, userInfo);

--- a/oauth-tokenstore-mongodb/src/main/java/de/adorsys/oauth/tokenstore/mongodb/TokenDocument.java
+++ b/oauth-tokenstore-mongodb/src/main/java/de/adorsys/oauth/tokenstore/mongodb/TokenDocument.java
@@ -68,7 +68,7 @@ public class TokenDocument<T extends Token> {
         } else if (token instanceof RefreshToken) {
             this.type = TokenType.REFRESH;
         } else {
-            throw new IllegalArgumentException("unknow token type " + token.getClass().getName());
+            throw new IllegalArgumentException("Unknow token type " + token.getClass().getName());
         }
         this.token = token;
         this.created = created;


### PR DESCRIPTION
Wir benötigen das Feature, dass der RefreshToken ein Ablaufdatum erhält.
Jede Anwendung kann dies an sowie ausschalten. Defaultmäßig ist das neue Feature deaktiviert.
Damit dies aktiviert wird, muss in der web.xml im jeweiligen Projekt folgendes eingetragen werden:

refreshlifetime
MILLISEKUNDEN_INDIVIDUELL

Der Wert 0 entspricht ebenfalls den Status deaktiviert und bedeutet somit unendlich.

Hinweis: Damit der Token auch gelöscht wird, muss in der Datenbank manuell ein TTL erstellt werden.