### PR TITLE
Bugfix Issue 55 - Auch bei Timeout Exception werfen

### DIFF
--- a/oauth-client-jaas/src/main/java/de/adorsys/oauth/client/protocol/UserInfoResolver.java
+++ b/oauth-client-jaas/src/main/java/de/adorsys/oauth/client/protocol/UserInfoResolver.java
@@ -103,8 +103,8 @@ public class UserInfoResolver {
             httpGet.setHeader("Authorization", new BearerAccessToken(accessToken.getValue()).toAuthorizationHeader());
 
             HttpCacheContext context = HttpCacheContext.create();
-            try {
-                CloseableHttpResponse userInfoResponse = cachingHttpClient.execute(httpGet, context);
+            try (CloseableHttpResponse userInfoResponse = cachingHttpClient.execute(httpGet, context)){
+
 
                 //TODO mask accessToken
                 LOG.debug("read userinfo {} {}", OAuthCredentialHasher.hashCredential(accessToken.getValue()), context.getCacheResponseStatus());

--- a/oauth-client-jaas/src/main/java/de/adorsys/oauth/client/protocol/UserInfoResolver.java
+++ b/oauth-client-jaas/src/main/java/de/adorsys/oauth/client/protocol/UserInfoResolver.java
@@ -103,7 +103,9 @@ public class UserInfoResolver {
             httpGet.setHeader("Authorization", new BearerAccessToken(accessToken.getValue()).toAuthorizationHeader());
 
             HttpCacheContext context = HttpCacheContext.create();
-            try (CloseableHttpResponse userInfoResponse = cachingHttpClient.execute(httpGet, context)){
+            try {
+                CloseableHttpResponse userInfoResponse = cachingHttpClient.execute(httpGet, context);
+
                 //TODO mask accessToken
                 LOG.debug("read userinfo {} {}", OAuthCredentialHasher.hashCredential(accessToken.getValue()), context.getCacheResponseStatus());
                 HttpEntity entity = userInfoResponse.getEntity();
@@ -116,6 +118,9 @@ public class UserInfoResolver {
                 entity.writeTo(baos);
     
                 return UserInfo.parse(baos.toString());
+            } catch (Exception e) {
+                // Auch bei einem Timeout die Exception weiterwerfen
+                throw new IllegalStateException(e);
             }
         } catch (Exception e) {
             throw new IllegalStateException(e);

--- a/oauth-client-jaas/src/main/java/de/adorsys/oauth/client/protocol/UserInfoResolver.java
+++ b/oauth-client-jaas/src/main/java/de/adorsys/oauth/client/protocol/UserInfoResolver.java
@@ -120,6 +120,7 @@ public class UserInfoResolver {
                 return UserInfo.parse(baos.toString());
             } catch (Exception e) {
                 // Auch bei einem Timeout die Exception weiterwerfen
+                LOG.warn("Exception beim accessing {}: ", userInfoEndpoint.toASCIIString(), e);
                 throw new IllegalStateException(e);
             }
         } catch (Exception e) {


### PR DESCRIPTION
Bitte prüfen - ändert das Verhalten im Fehlerfall (Timeout zw. Client->IDP)
Bisher wurde hier ein http 200 mit leerem Body zurück geliefert; neu sollte ein http 401 kommen.